### PR TITLE
Misleading label

### DIFF
--- a/app/views/transactionInfos.html
+++ b/app/views/transactionInfos.html
@@ -53,7 +53,7 @@
                 </td>
             </tr>
             <tr>
-                <td>Gas Used</td>
+                <td>Gas</td>
                 <td>{{gas}}</td>
             </tr>
             <tr>


### PR DESCRIPTION
Gas is a TX parameter, attacched when client sign the TX. Gas used is stored in the TX's receipt after the TX is actually mined into a block.