### PR TITLE
fix: getBlockTransactionCount doesn't work on testRPC

### DIFF
--- a/app/scripts/controllers/blockInfosController.js
+++ b/app/scripts/controllers/blockInfosController.js
@@ -41,6 +41,7 @@ angular.module('ethExplorer')
                     $scope.extraData = result.extraData;
                     $scope.dataFromHex = hex2a(result.extraData);
                     $scope.size = result.size;
+                    $scope.txCount = result.transactions.length;
                     if($scope.blockNumber!==undefined){
                         $scope.conf = number - $scope.blockNumber + " Confirmations";
                         if($scope.conf===0 + " Confirmations"){
@@ -55,9 +56,7 @@ angular.module('ethExplorer')
                             $scope.time = newDate.toUTCString();
                         }
                     }
-
-
-
+                    getTransactions(result);
                 });
 
             } else {
@@ -70,6 +69,7 @@ angular.module('ethExplorer')
 
                 web3.eth.getBlock($scope.blockId,function(error, result) {
                     if(!error) {
+                        //console.debug("getBlockInfos: ", result);
                         deferred.resolve(result);
                     } else {
                         deferred.reject(error);
@@ -79,18 +79,21 @@ angular.module('ethExplorer')
 
             }
 
-
         };
         $scope.init();
 
-        // parse transactions
-        $scope.transactions = []
-        web3.eth.getBlockTransactionCount($scope.blockId, function(error, result){
-          var txCount = result
+        function getTransactions(result) {
+          // parse transactions
+          // getBlockTransactionCount doesn't work on testRPC
+          //  web3.eth.getBlockTransactionCount($scope.blockId, function(error, result){
+          //var txCount = result
+
+          txCount = result.transactions.length;
+          $scope.transactions = []
 
           for (var blockIdx = 0; blockIdx < txCount; blockIdx++) {
             web3.eth.getTransactionFromBlock($scope.blockId, blockIdx, function(error, result) {
-
+              // console.debug("getTransactionFromBlock: ", result);
               var transaction = {
                 id: result.hash,
                 hash: result.hash,
@@ -105,8 +108,8 @@ angular.module('ethExplorer')
               )
             })
           }
-        })
-
+        } // getTransactions()
+        //}) //getBlockTransactionCount
 
 function hex2a(hexx) {
     var hex = hexx.toString();//force conversion

--- a/app/views/blockInfos.html
+++ b/app/views/blockInfos.html
@@ -53,6 +53,10 @@
                 <td>{{gasLimit}}</td>
             </tr>
             <tr>
+                <td>Tx Count</td>
+                <td>{{txCount}}</td>
+            </tr>
+            <tr>
                 <td>Data</td>
                 <td>{{extraData}}</td>
             </tr>


### PR DESCRIPTION
I've received  `Error: RPC method eth_getBlockTransactionCountByNumber not supported.` when I tried to use it on local testRPC. 
This fix is using the already received result.transactions.length instead of querying again for tx count.